### PR TITLE
Increase block times and limits + fix duplicate hash crash.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,7 +1582,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1590,7 +1590,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1608,7 +1608,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "chrono",
  "frame-benchmarking",
@@ -1628,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1644,7 +1644,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1655,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1680,7 +1680,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.24",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -1713,7 +1713,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1729,7 +1729,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4080,7 +4080,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4101,7 +4101,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4117,7 +4117,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4130,7 +4130,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4150,7 +4150,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4199,7 +4199,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "jsonrpc-core 15.1.0",
  "jsonrpc-core-client",
@@ -4217,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5428,7 +5428,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "futures 0.3.7",
  "futures-timer 3.0.2",
@@ -5452,7 +5452,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5469,7 +5469,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -5490,7 +5490,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -5501,7 +5501,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5555,7 +5555,7 @@ dependencies = [
 [[package]]
 name = "sc-cli-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.24",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "fnv",
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5633,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5644,7 +5644,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.7",
@@ -5675,7 +5675,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "fork-tree",
@@ -5720,7 +5720,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -5733,7 +5733,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "futures 0.3.7",
  "futures-timer 3.0.2",
@@ -5756,7 +5756,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "log 0.4.11",
  "sc-client-api",
@@ -5770,7 +5770,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "lazy_static",
@@ -5799,7 +5799,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "log 0.4.11",
@@ -5816,7 +5816,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -5831,7 +5831,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -5849,7 +5849,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "finality-grandpa",
@@ -5886,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.7",
@@ -5904,7 +5904,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -5924,7 +5924,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -5943,7 +5943,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "async-std",
  "async-trait",
@@ -5997,7 +5997,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "futures 0.3.7",
  "futures-timer 3.0.2",
@@ -6012,7 +6012,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -6039,7 +6039,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "futures 0.3.7",
  "libp2p",
@@ -6052,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "log 0.4.11",
  "substrate-prometheus-endpoint",
@@ -6061,7 +6061,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "futures 0.3.7",
  "hash-db",
@@ -6094,7 +6094,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.7",
@@ -6118,7 +6118,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core 15.1.0",
@@ -6136,7 +6136,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "directories",
@@ -6200,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6214,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "futures 0.3.7",
  "futures-timer 3.0.2",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "erased-serde",
  "log 0.4.11",
@@ -6254,7 +6254,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.7",
@@ -6275,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.7",
@@ -6714,7 +6714,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "log 0.4.11",
@@ -6726,7 +6726,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -6741,7 +6741,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -6753,7 +6753,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -6765,7 +6765,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -6778,7 +6778,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -6789,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6801,7 +6801,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "log 0.4.11",
@@ -6818,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "serde",
  "serde_json",
@@ -6827,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.7",
@@ -6853,7 +6853,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6867,7 +6867,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -6887,7 +6887,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -6896,7 +6896,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -6908,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -6951,7 +6951,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -6960,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -6970,7 +6970,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -6981,7 +6981,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "finality-grandpa",
  "log 0.4.11",
@@ -6998,7 +6998,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "parity-scale-codec",
@@ -7010,7 +7010,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "futures 0.3.7",
  "hash-db",
@@ -7034,7 +7034,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7045,7 +7045,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -7061,7 +7061,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7071,7 +7071,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "backtrace",
  "log 0.4.11",
@@ -7080,7 +7080,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "serde",
  "sp-core",
@@ -7089,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7111,7 +7111,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "primitive-types 0.7.2",
@@ -7127,7 +7127,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7139,7 +7139,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "serde",
  "serde_json",
@@ -7148,7 +7148,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7161,7 +7161,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7171,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "hash-db",
  "log 0.4.11",
@@ -7192,12 +7192,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "impl-serde 0.3.1",
  "parity-scale-codec",
@@ -7210,7 +7210,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "log 0.4.11",
  "sp-core",
@@ -7223,7 +7223,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7237,7 +7237,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -7250,7 +7250,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.7",
@@ -7265,7 +7265,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7279,7 +7279,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "futures 0.3.7",
  "futures-core",
@@ -7291,7 +7291,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "impl-serde 0.3.1",
  "parity-scale-codec",
@@ -7303,7 +7303,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7430,7 +7430,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "platforms",
 ]
@@ -7438,7 +7438,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.7",
@@ -7461,7 +7461,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 dependencies = [
  "async-std",
  "derive_more 0.99.11",
@@ -7475,7 +7475,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate.git#510e68b8d06a3d407eda0d4c1c330bd484140b65"
+source = "git+https://github.com/hicommonwealth/substrate.git?branch=increase-size-limits#5382b6c983e93cdb2b1b632401f0e7ffc244a502"
 
 [[package]]
 name = "subtle"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,42 +18,42 @@ name = "node-template"
 [dependencies]
 structopt = "0.3.8"
 
-sc-cli = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git", features = ["wasmtime"] }
-sp-core = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-sp-keystore = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git" }
-sc-executor = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git", features = ["wasmtime"] }
-sc-service = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git", features = ["wasmtime"] }
-sp-inherents = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-sc-transaction-pool = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-sp-transaction-pool = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-sc-consensus-aura = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git" }
-sp-consensus-aura = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git" }
-sp-consensus = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git" }
-sc-consensus = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git" }
-sc-finality-grandpa = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git" }
-sp-finality-grandpa = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-sc-client-api = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-sp-runtime = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
+sc-cli = { version = "0.8.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", features = ["wasmtime"] }
+sp-core = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-keystore = { version = "0.8.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sc-executor = { version = "0.8.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", features = ["wasmtime"] }
+sc-service = { version = "0.8.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", features = ["wasmtime"] }
+sp-inherents = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sc-transaction-pool = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-transaction-pool = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sc-consensus-aura = { version = "0.8.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-consensus-aura = { version = "0.8.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-consensus = { version = "0.8.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sc-consensus = { version = "0.8.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sc-finality-grandpa = { version = "0.8.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-finality-grandpa = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sc-client-api = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-runtime = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
 
 # These dependencies are used for the node template's RPCs
 jsonrpc-core = "15.0.0"
-sc-rpc = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-sp-api = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-sc-rpc-api = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git" }
-sp-blockchain = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-sp-block-builder = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-sc-basic-authorship = { version = "0.8.0", git = "https://github.com/paritytech/substrate.git" }
-substrate-frame-rpc-system = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-pallet-transaction-payment-rpc = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
+sc-rpc = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-api = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sc-rpc-api = { version = "0.8.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-blockchain = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-block-builder = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sc-basic-authorship = { version = "0.8.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+substrate-frame-rpc-system = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+pallet-transaction-payment-rpc = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
 
 # These dependencies are used for runtime benchmarking
-frame-benchmarking = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
-frame-benchmarking-cli = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
+frame-benchmarking = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+frame-benchmarking-cli = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
 
 node-template-runtime = { version = "2.0.0", path = "../runtime" }
 
 [build-dependencies]
-substrate-build-script-utils = { version = "2.0.0", git = "https://github.com/paritytech/substrate.git" }
+substrate-build-script-utils = { version = "2.0.0", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
 
 [features]
 default = []

--- a/pallets/worker/Cargo.toml
+++ b/pallets/worker/Cargo.toml
@@ -17,15 +17,15 @@ codec = { package = "parity-scale-codec", version = "1.3.4", default-features = 
 serde = { version = "1.0", default-features = false, optional = true }
 serde_derive = { version = "1.0", optional = true }
 safe-mix = { version = "1.0", default-features = false }
-sp-application-crypto = { git = "https://github.com/paritytech/substrate.git", default-features = false }
-sp-arithmetic = { git = "https://github.com/paritytech/substrate.git", default-features = false }
-sp-std = { git = "https://github.com/paritytech/substrate.git", default-features = false }
-sp-io = { git = "https://github.com/paritytech/substrate.git", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate.git", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/substrate.git", default-features = false }
-frame-support = { git = "https://github.com/paritytech/substrate.git", default-features = false }
-frame-system = { git = "https://github.com/paritytech/substrate.git", default-features = false }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate.git", default-features = false }
+sp-application-crypto = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false }
+sp-arithmetic = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false }
+sp-std = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false }
+sp-io = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false }
+sp-core = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false }
+sp-runtime = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false }
+frame-support = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false }
+frame-system = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false }
+pallet-timestamp = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false }
 lite-json = { git = "https://github.com/jnaviask/lite-json.git", branch = "jnaviask.fix-empty-array-parsing", default-features = false }
 ethereum = { version = "0.4", default-features = false, features = ["with-codec"] }
 ethereum-types = { version = "0.9", default-features = false }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,44 +13,44 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.4", default-features = false, features = ["derive"] }
 
-pallet-aura = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-pallet-balances = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-frame-support = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-pallet-grandpa = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-pallet-randomness-collective-flip = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-pallet-sudo = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-frame-system = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-pallet-timestamp = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-pallet-transaction-payment = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-frame-executive = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
+pallet-aura = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+pallet-balances = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+frame-support = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+pallet-grandpa = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+pallet-randomness-collective-flip = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+pallet-sudo = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+frame-system = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+pallet-timestamp = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+pallet-transaction-payment = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+frame-executive = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-api = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-sp-block-builder = { git = "https://github.com/paritytech/substrate.git", default-features = false, version = "2.0.0"}
-sp-consensus-aura = { version = "0.8.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-sp-inherents = { git = "https://github.com/paritytech/substrate.git", default-features = false, version = "2.0.0"}
-sp-offchain = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-sp-runtime = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-sp-session = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-sp-std = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-sp-transaction-pool = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-sp-version = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
+sp-api = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-block-builder = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false, version = "2.0.0"}
+sp-consensus-aura = { version = "0.8.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-core = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-inherents = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false, version = "2.0.0"}
+sp-offchain = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-runtime = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-session = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-std = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-transaction-pool = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+sp-version = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
 
 # Used for the node template's RPCs
-frame-system-rpc-runtime-api = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
-pallet-indices = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git" }
+frame-system-rpc-runtime-api = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
+pallet-indices = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
 
 # Used for runtime benchmarking
-frame-benchmarking = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", optional = true }
-frame-system-benchmarking = { version = "2.0.0", default-features = false, git = "https://github.com/paritytech/substrate.git", optional = true }
+frame-benchmarking = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", optional = true }
+frame-system-benchmarking = { version = "2.0.0", default-features = false, git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", optional = true }
 hex-literal = { version = "0.3.1", optional = true }
 
-sp-application-crypto = { git = "https://github.com/paritytech/substrate.git", default-features = false }
+sp-application-crypto = { git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits", default-features = false }
 pallet-worker = { version = "2.0.0", default-features = false, path = "../pallets/worker" }
 
 [build-dependencies]
-wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/paritytech/substrate.git" }
+wasm-builder-runner = { package = "substrate-wasm-builder-runner", git = "https://github.com/hicommonwealth/substrate.git", branch = "increase-size-limits" }
 
 [features]
 default = ["std"]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -104,7 +104,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	transaction_version: 1,
 };
 
-pub const MILLISECS_PER_BLOCK: u64 = 6000;
+pub const MILLISECS_PER_BLOCK: u64 = 10000;
 
 pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
 
@@ -125,12 +125,12 @@ pub fn native_version() -> NativeVersion {
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 2400;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
-	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
+	pub const MaximumBlockWeight: Weight = 6 * WEIGHT_PER_SECOND;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	/// Assume 10% of weight for average on_initialize calls.
 	pub MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
 		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
-	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
+	pub const MaximumBlockLength: u32 = 128 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 }
 


### PR DESCRIPTION
Increases block time to 10s and pegs to a version of substrate with increased block size limits.

Also, fixes a crash when attempting to add a new header just after init.

Note that the increased block size limits are untested and may result in unstable or insecure behavior.